### PR TITLE
Allow for the db.json file to be committed but none of the other node…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ composer.phar
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock
-node_modules/
+node_modules/mime-db/*
+!node_modules/mime-db/db.json


### PR DESCRIPTION
…_modules

My use case is this package is used by CiviCRM a CRM library which is then deployed using composer on a Drupal 8 instance. That is then managed by git and the current version of the .gitignore means that when we commit into our site repository we are missing the db.json file this fixes it