### PR TITLE
Fix PHP8.2 Deprecation notice about Dynamic Property

### DIFF
--- a/src/Repository/MimeDbRepository.php
+++ b/src/Repository/MimeDbRepository.php
@@ -16,6 +16,14 @@ namespace MimeTyper\Repository;
  */
 class MimeDbRepository extends AbstractRepository
 {
+
+    /**
+     * minetype db file name
+     *
+     * @var string
+     */
+    protected $filename;
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
This aims to resolve the following deprecation notice by declaring the property on the class

```
Creation of dynamic property MimeTyper\Repository\MimeDbRepository::$filename is deprecated
```